### PR TITLE
"Destroyed" instead of "Kills"

### DIFF
--- a/locale/en/Pacifist.cfg
+++ b/locale/en/Pacifist.cfg
@@ -46,6 +46,7 @@ enemies=Units
 [map-gen-preset-description]
 default=You have to turn off biters yourself - unless you like to suffer.
 pacifist-default=Like default, but biters are disabled for your convenience.
+rail-world=Resource patches are large and spread far apart to encourage train systems.
 
 [map-gen-preset-name]
 default=Vanilla Default (biters will be killed on load)

--- a/locale/en/Pacifist.cfg
+++ b/locale/en/Pacifist.cfg
@@ -3,6 +3,17 @@ guns=Tool
 weapons=
 ammo=Tool charges
 
+[gui-game-finished]
+kills=Destroyed
+
+[gui-production]
+kills=Losses
+
+[gui-kills]
+title=Losses
+kills=Destroyed
+loses=Losses
+
 [inventory-full-message]
 guns=Tool slots are full.
 ammo=Tool charge slots are full.


### PR DESCRIPTION
It's still possible to destroy things, but make it sound less violent. I left "train kills" in the info for a train, since I didn't have a better wording for that... and the trains still are potentially violent.

Looking at the strings, I also noticed the rail world description references biters, so I removed that sentence.