### PR TITLE
Mod compatibility: Throwable Capture Bot

### DIFF
--- a/compatibility/space-age.lua
+++ b/compatibility/space-age.lua
@@ -70,9 +70,11 @@ local modify_capture_bot = function()
     )
 
     local capture_bot = data.raw.ammo["capture-robot-rocket"]
-    capture_bot.ammo_type.target_filter = { "biter-spawner" }
-    capture_bot.ammo_category = "capture-robot"
-    capture_bot.subgroup = "capture"
+    if capture_bot ~= nil then
+        capture_bot.ammo_type.target_filter = { "biter-spawner" }
+        capture_bot.ammo_category = "capture-robot"
+        capture_bot.subgroup = "capture"
+    end
 
     local rocket_launcher = data.raw.gun["rocket-launcher"]
     rocket_launcher.attack_parameters.ammo_category = "capture-robot"

--- a/compatibility/throwable-capture-robot.lua
+++ b/compatibility/throwable-capture-robot.lua
@@ -1,0 +1,25 @@
+-- Mod compatibility for Throwable Capture Bot (https://mods.factorio.com/mod/throwable-capture-robot)
+local throwable_capture_robot_config = {
+    exceptions = {
+        capsule = { "capture-robot-capsule" },
+    },
+    preprocess = {
+        function()
+            local capture_bot_capsule = data.raw.capsule["capture-robot-capsule"]
+            capture_bot_capsule.subgroup = "capture"
+            capture_bot_capsule.capsule_action.attack_parameters.ammo_category = "capture-robot"
+            capture_bot_capsule.capsule_action.attack_parameters.ammo_type.target_filter = { "biter-spawner" }
+        end,
+    },
+}
+
+-- Check mod startup setting "Replace capture bot rocket with capsule"
+if settings.startup["throwable-capture-robot-replace-rocket"].value then
+    -- If the mod replaces (i.e. removes) the capture bot rocket, the rocket launcher doesn't have a use anymore and
+    -- therefore can be removed.
+    throwable_capture_robot_config.extra = {
+        gun = { "rocket-launcher" },
+    }
+end
+
+return throwable_capture_robot_config

--- a/info.json
+++ b/info.json
@@ -15,6 +15,7 @@
     "! alien-module",
     "(?) Dectorio",
     "(?) EditorExtensions",
-    "(?) IntermodalContainers"
+    "(?) IntermodalContainers",
+    "(?) throwable-capture-robot"
   ]
 }

--- a/locale/en/Pacifist.cfg
+++ b/locale/en/Pacifist.cfg
@@ -87,8 +87,14 @@ captive-biter-spawner=Controlled spore deposit
 capture-robot-rocket=Bio probe
 biter-egg=Spore sample
 
+# Mod compatibility: Throwable Capture Bot
+capture-robot-capsule=Bio probe capsule
+
 [item-description]
 capture-robot-rocket=Probes the targeted [entity=biter-spawner] and converts it into a [entity=captive-biter-spawner].
+
+# Mod compatibility: Throwable Capture Bot
+capture-robot-capsule=Probes the targeted [entity=biter-spawner] and converts it into a [entity=captive-biter-spawner].
 
 [map-gen-preset-name]
 default=Vanilla Default


### PR DESCRIPTION
This PR adds compatibility for my upcoming mod [Throwable Capture Bot](https://github.com/binaryDiv/factorio-throwable-capture-robot) which adds a throwable alternative to the Capture Bot Rocket, optionally (by default) replacing the rocket with the capsule.

Needs a small change in the Space Age compatibility module.