### PR TITLE
Fix base productivity bonus in Space Age machines

### DIFF
--- a/functions/pollution.lua
+++ b/functions/pollution.lua
@@ -21,8 +21,9 @@ local _remove_from_modules = function(data_raw)
     end
     data_raw:apply_to_all(types.entities_with_energy_source,
         function(entity)
-            if entity.effect_receiver and entity.effect_receiver.base_effect then
-                entity.effect_receiver.base_effect = nil
+            local base_effect = entity.effect_receiver and entity.effect_receiver.base_effect or {}
+            if base_effect and base_effect.pollution then
+                base_effect.pollution = nil
             end
         end
     )

--- a/functions/pollution.lua
+++ b/functions/pollution.lua
@@ -21,7 +21,7 @@ local _remove_from_modules = function(data_raw)
     end
     data_raw:apply_to_all(types.entities_with_energy_source,
         function(entity)
-            local base_effect = entity.effect_receiver and entity.effect_receiver.base_effect or {}
+            local base_effect = entity.effect_receiver and entity.effect_receiver.base_effect
             if base_effect and base_effect.pollution then
                 base_effect.pollution = nil
             end


### PR DESCRIPTION
The pollution removal code currently removes **all** base effects from machines. This sadly includes the 50+ base productivity bonus that some of the Space Age crafting machines have, like the Foundry or the Electromagnetic plant.

This PR fixes that issue by only setting `base_effect.pollution` to nil.